### PR TITLE
Batch parallel synonym retrieval and save

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ API keys are required to authenticate with the LLM providers. They can be provid
 
 If the required API key for the selected `llm_model_name` is not found either via its flag or environment variable, the application will print an error and exit.
 
+#### Parallel Processing Configuration
+
+The application supports parallel batch processing of LLM requests to improve performance when building the information structure from Prometheus. This is especially useful when dealing with large numbers of metrics and labels.
+
+*   **`-batch_size`** (Command-line flag)
+    *   Specifies the number of items (metrics or labels) to process in a single LLM request.
+    *   Default: `10`
+    *   Example: `-batch_size=20` will process 20 items per LLM request.
+
+*   **`-max_workers`** (Command-line flag)
+    *   Specifies the maximum number of parallel workers making concurrent LLM requests.
+    *   Default: `5`
+    *   Example: `-max_workers=10` will allow up to 10 concurrent LLM requests.
+
+**Note:** Increasing these values can significantly speed up the initial information structure building phase, but be mindful of:
+- Your LLM provider's rate limits
+- API costs (more parallel requests may consume your quota faster)
+- Memory usage on your system
+
 ## 4. Running the Application
 
 ### 4.1. Build
@@ -90,6 +109,14 @@ export OPENAI_API_KEY="your_openai_api_key_here"
 export PROMETHEUS_URL="http://localhost:9090"
 ./nlpromql -mode="chat" -llm_model_name="openai/gpt-3.5-turbo" -openai_api_key="your_openai_api_key_here"
 ```
+
+**Example with custom batch processing configuration:**
+```bash
+export PROMETHEUS_URL="http://localhost:9090"
+export OPENAI_API_KEY="your_openai_api_key_here"
+./nlpromql -mode="chat" -llm_model_name="openai/gpt-3.5-turbo" -batch_size=20 -max_workers=10
+```
+This configuration will process 20 metrics/labels per LLM request with up to 10 concurrent workers, significantly speeding up the initial information structure build.
 
 **Example with Anthropic (using environment variable for API key):**
 ```bash

--- a/info_structure/builder.go
+++ b/info_structure/builder.go
@@ -189,13 +189,15 @@ func (is *InfoStructure) updateMetricMap(allMetricNames []string,
 			newMetricMap[metric] = ""
 		}
 	}
-	fmt.Printf("%d", len(newMetricNames))
+	log.Printf("Found %d new metrics to process for synonyms", len(newMetricNames))
 	// Get metric synonyms (only for new metrics)
 	if len(newMetricNames) > 0 {
+		log.Printf("Processing metric synonyms in parallel batches...")
 		newMetricSynonyms, err := is.llmClient.GetMetricSynonyms(newMetricMap)
 		if err != nil {
 			return fmt.Errorf("error getting metric synonyms: %w", err)
 		}
+		log.Printf("Successfully processed %d metric synonyms", len(newMetricSynonyms))
 		if is.MetricMap.Map == nil {
 			is.MetricMap.Map = make(map[string]map[string]struct{})
 		}
@@ -232,12 +234,15 @@ func (is *InfoStructure) updateLabelMap(allLabelNames []string) error {
 		}
 	}
 
+	log.Printf("Found %d new labels to process for synonyms", len(newLabelNames))
 	// Get label synonyms (only for new labels)
 	if len(newLabelNames) > 0 {
+		log.Printf("Processing label synonyms in parallel batches...")
 		newLabelSynonyms, err := is.llmClient.GetLabelSynonyms(newLabelNames)
 		if err != nil {
 			return fmt.Errorf("error getting label synonyms: %w", err)
 		}
+		log.Printf("Successfully processed %d label synonyms", len(newLabelSynonyms))
 		if is.LabelMap.Map == nil {
 			is.LabelMap.Map = make(map[string]map[string]struct{})
 		}

--- a/langchain/batch_processor.go
+++ b/langchain/batch_processor.go
@@ -1,0 +1,300 @@
+package langchain
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+)
+
+// BatchProcessor handles parallel batch processing of LLM requests
+type BatchProcessor struct {
+	batchSize int
+	maxWorkers int
+}
+
+// NewBatchProcessor creates a new batch processor with specified batch size and max workers
+func NewBatchProcessor(batchSize, maxWorkers int) *BatchProcessor {
+	if batchSize <= 0 {
+		batchSize = 10 // default batch size
+	}
+	if maxWorkers <= 0 {
+		maxWorkers = 5 // default max workers
+	}
+	return &BatchProcessor{
+		batchSize:  batchSize,
+		maxWorkers: maxWorkers,
+	}
+}
+
+// ProcessMetricBatches processes metric synonym requests in parallel batches
+func (bp *BatchProcessor) ProcessMetricBatches(
+	ctx context.Context,
+	metricMap map[string]string,
+	processFunc func(batch map[string]string) (map[string][]string, error),
+) (map[string][]string, error) {
+	
+	// Create batches
+	batches := bp.createMetricBatches(metricMap)
+	log.Printf("Created %d metric batches (batch size: %d, total metrics: %d)", 
+		len(batches), bp.batchSize, len(metricMap))
+	
+	// Process batches in parallel
+	log.Printf("Processing metric batches with %d parallel workers", bp.maxWorkers)
+	results, err := bp.processBatchesInParallel(ctx, batches, processFunc)
+	if err != nil {
+		return nil, err
+	}
+	
+	// Merge results
+	merged := make(map[string][]string)
+	for _, result := range results {
+		for k, v := range result {
+			merged[k] = v
+		}
+	}
+	
+	log.Printf("Successfully processed all metric batches, total results: %d", len(merged))
+	return merged, nil
+}
+
+// ProcessLabelBatches processes label synonym requests in parallel batches
+func (bp *BatchProcessor) ProcessLabelBatches(
+	ctx context.Context,
+	labels []string,
+	processFunc func(batch []string) (map[string][]string, error),
+) (map[string][]string, error) {
+	
+	// Create batches
+	batches := bp.createLabelBatches(labels)
+	log.Printf("Created %d label batches (batch size: %d, total labels: %d)", 
+		len(batches), bp.batchSize, len(labels))
+	
+	// Process batches in parallel
+	log.Printf("Processing label batches with %d parallel workers", bp.maxWorkers)
+	results, err := bp.processLabelBatchesInParallel(ctx, batches, processFunc)
+	if err != nil {
+		return nil, err
+	}
+	
+	// Merge results
+	merged := make(map[string][]string)
+	for _, result := range results {
+		for k, v := range result {
+			merged[k] = v
+		}
+	}
+	
+	log.Printf("Successfully processed all label batches, total results: %d", len(merged))
+	return merged, nil
+}
+
+// createMetricBatches splits the metric map into smaller batches
+func (bp *BatchProcessor) createMetricBatches(metricMap map[string]string) []map[string]string {
+	var batches []map[string]string
+	currentBatch := make(map[string]string)
+	count := 0
+	
+	for metric, desc := range metricMap {
+		currentBatch[metric] = desc
+		count++
+		
+		if count >= bp.batchSize {
+			batches = append(batches, currentBatch)
+			currentBatch = make(map[string]string)
+			count = 0
+		}
+	}
+	
+	// Add remaining items
+	if len(currentBatch) > 0 {
+		batches = append(batches, currentBatch)
+	}
+	
+	return batches
+}
+
+// createLabelBatches splits the label slice into smaller batches
+func (bp *BatchProcessor) createLabelBatches(labels []string) [][]string {
+	var batches [][]string
+	
+	for i := 0; i < len(labels); i += bp.batchSize {
+		end := i + bp.batchSize
+		if end > len(labels) {
+			end = len(labels)
+		}
+		batches = append(batches, labels[i:end])
+	}
+	
+	return batches
+}
+
+// processBatchesInParallel processes metric batches concurrently
+func (bp *BatchProcessor) processBatchesInParallel(
+	ctx context.Context,
+	batches []map[string]string,
+	processFunc func(batch map[string]string) (map[string][]string, error),
+) ([]map[string][]string, error) {
+	
+	// Create channels for work distribution
+	workCh := make(chan map[string]string, len(batches))
+	resultCh := make(chan map[string][]string, len(batches))
+	errorCh := make(chan error, len(batches))
+	
+	// Start workers
+	var wg sync.WaitGroup
+	workerCount := bp.maxWorkers
+	if len(batches) < workerCount {
+		workerCount = len(batches)
+	}
+	
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for batch := range workCh {
+				select {
+				case <-ctx.Done():
+					errorCh <- ctx.Err()
+					return
+				default:
+					result, err := processFunc(batch)
+					if err != nil {
+						errorCh <- fmt.Errorf("batch processing failed: %w", err)
+						return
+					}
+					resultCh <- result
+				}
+			}
+		}()
+	}
+	
+	// Send work to workers
+	go func() {
+		for _, batch := range batches {
+			select {
+			case <-ctx.Done():
+				close(workCh)
+				return
+			case workCh <- batch:
+			}
+		}
+		close(workCh)
+	}()
+	
+	// Wait for all workers to complete
+	wg.Wait()
+	close(resultCh)
+	close(errorCh)
+	
+	// Collect errors and results
+	var firstError error
+	var results []map[string][]string
+	
+	// Collect all results first
+	for result := range resultCh {
+		results = append(results, result)
+	}
+	
+	// Then check for errors (non-blocking read from closed channel)
+	select {
+	case err := <-errorCh:
+		if err != nil {
+			firstError = err
+		}
+	default:
+		// No errors
+	}
+	
+	// Return error if any
+	if firstError != nil {
+		return nil, firstError
+	}
+	
+	return results, nil
+}
+
+// processLabelBatchesInParallel processes label batches concurrently
+func (bp *BatchProcessor) processLabelBatchesInParallel(
+	ctx context.Context,
+	batches [][]string,
+	processFunc func(batch []string) (map[string][]string, error),
+) ([]map[string][]string, error) {
+	
+	// Create channels for work distribution
+	workCh := make(chan []string, len(batches))
+	resultCh := make(chan map[string][]string, len(batches))
+	errorCh := make(chan error, len(batches))
+	
+	// Start workers
+	var wg sync.WaitGroup
+	workerCount := bp.maxWorkers
+	if len(batches) < workerCount {
+		workerCount = len(batches)
+	}
+	
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for batch := range workCh {
+				select {
+				case <-ctx.Done():
+					errorCh <- ctx.Err()
+					return
+				default:
+					result, err := processFunc(batch)
+					if err != nil {
+						errorCh <- fmt.Errorf("batch processing failed: %w", err)
+						return
+					}
+					resultCh <- result
+				}
+			}
+		}()
+	}
+	
+	// Send work to workers
+	go func() {
+		for _, batch := range batches {
+			select {
+			case <-ctx.Done():
+				close(workCh)
+				return
+			case workCh <- batch:
+			}
+		}
+		close(workCh)
+	}()
+	
+	// Wait for all workers to complete
+	wg.Wait()
+	close(resultCh)
+	close(errorCh)
+	
+	// Collect errors and results
+	var firstError error
+	var results []map[string][]string
+	
+	// Collect all results first
+	for result := range resultCh {
+		results = append(results, result)
+	}
+	
+	// Then check for errors (non-blocking read from closed channel)
+	select {
+	case err := <-errorCh:
+		if err != nil {
+			firstError = err
+		}
+	default:
+		// No errors
+	}
+	
+	// Return error if any
+	if firstError != nil {
+		return nil, firstError
+	}
+	
+	return results, nil
+}

--- a/langchain/client.go
+++ b/langchain/client.go
@@ -14,14 +14,24 @@ import (
 
 // LangChainClient implements the llm.LLMClient interface using LangChainGo.
 type LangChainClient struct {
-	llmModel llms.Model // Generic LangChainGo LLM model
+	llmModel       llms.Model      // Generic LangChainGo LLM model
+	batchProcessor *BatchProcessor // Batch processor for parallel processing
 }
 
 // NewLangChainClient creates a new LangChainClient.
 // The specific model (e.g., OpenAI, Anthropic) should be initialized and passed here.
 func NewLangChainClient(model llms.Model) *LangChainClient {
 	return &LangChainClient{
-		llmModel: model,
+		llmModel:       model,
+		batchProcessor: NewBatchProcessor(10, 5), // Default batch size of 10, max 5 workers
+	}
+}
+
+// NewLangChainClientWithBatchConfig creates a new LangChainClient with custom batch configuration.
+func NewLangChainClientWithBatchConfig(model llms.Model, batchSize, maxWorkers int) *LangChainClient {
+	return &LangChainClient{
+		llmModel:       model,
+		batchProcessor: NewBatchProcessor(batchSize, maxWorkers),
 	}
 }
 
@@ -31,7 +41,19 @@ func (c *LangChainClient) GetMetricSynonyms(metricMap map[string]string) (map[st
 		return nil, errors.New("LangChain LLM model is not initialized")
 	}
 
-	metricMapJSON, err := json.MarshalIndent(metricMap, "", "  ")
+	// If the metric map is small, process it directly without batching
+	if len(metricMap) <= c.batchProcessor.batchSize {
+		return c.getMetricSynonymsBatch(metricMap)
+	}
+
+	// Process in parallel batches
+	ctx := context.Background()
+	return c.batchProcessor.ProcessMetricBatches(ctx, metricMap, c.getMetricSynonymsBatch)
+}
+
+// getMetricSynonymsBatch processes a single batch of metrics
+func (c *LangChainClient) getMetricSynonymsBatch(metricBatch map[string]string) (map[string][]string, error) {
+	metricMapJSON, err := json.MarshalIndent(metricBatch, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling metricMap: %w", err)
 	}
@@ -71,7 +93,19 @@ func (c *LangChainClient) GetLabelSynonyms(labelNames []string) (map[string][]st
 		return nil, errors.New("LangChain LLM model is not initialized")
 	}
 
-	labelNamesJSON, err := json.MarshalIndent(labelNames, "", "  ")
+	// If the label list is small, process it directly without batching
+	if len(labelNames) <= c.batchProcessor.batchSize {
+		return c.getLabelSynonymsBatch(labelNames)
+	}
+
+	// Process in parallel batches
+	ctx := context.Background()
+	return c.batchProcessor.ProcessLabelBatches(ctx, labelNames, c.getLabelSynonymsBatch)
+}
+
+// getLabelSynonymsBatch processes a single batch of labels
+func (c *LangChainClient) getLabelSynonymsBatch(labelBatch []string) (map[string][]string, error) {
+	labelNamesJSON, err := json.MarshalIndent(labelBatch, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling labelNames: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -26,6 +26,8 @@ func main() {
 	openaiAPIKeyFlag := flag.String("openai_api_key", "", "OpenAI API key. Overrides OPENAI_API_KEY environment variable.")
 	anthropicAPIKeyFlag := flag.String("anthropic_api_key", "", "Anthropic API key. Overrides ANTHROPIC_API_KEY environment variable.")
 	_ = flag.String("cohere_api_key", "", "Cohere API key. Overrides COHERE_API_KEY environment variable.") // Defined, not used yet - assigned to blank identifier
+	batchSize := flag.Int("batch_size", 10, "Batch size for parallel LLM requests when building information structure")
+	maxWorkers := flag.Int("max_workers", 5, "Maximum number of parallel workers for LLM requests")
 
 	flag.Parse()
 
@@ -84,12 +86,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	chosenLLMClient := langchain.NewLangChainClient(lcModel)
+	chosenLLMClient := langchain.NewLangChainClientWithBatchConfig(lcModel, *batchSize, *maxWorkers)
 	// NewLangChainClient currently doesn't return an error. If it could, error should be handled:
 	// if err != nil {
 	// fmt.Fprintf(os.Stderr, "Error creating LangChainClient: %v\n", err)
 	// os.Exit(1)
 	// }
+	
+	fmt.Printf("LLM client configured with batch size: %d, max workers: %d\n", *batchSize, *maxWorkers)
 
 	// 3. Get Prometheus Credentials from Environment Variables
 	promURL, promUser, promPassword, err := getPrometheusCredentials()


### PR DESCRIPTION
Implement parallel batch processing for `GetMetricSynonyms` and `GetLabelSynonyms` to improve performance when fetching LLM synonyms.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb3a4d14-f09f-4763-a56b-aeba9eb278cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fb3a4d14-f09f-4763-a56b-aeba9eb278cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

